### PR TITLE
Remove .NET 10 SDK installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,29 +83,6 @@ EF QueryLens translates EF Core LINQ to SQL at hover time. A shared daemon does 
 >
 > EF QueryLens launches bundled backend processes via `dotnet`, so SQL preview features will not start if .NET 10 is missing.
 
-Install quickly with the official installer scripts:
-
-**PowerShell (Windows)**
-
-```powershell
-Invoke-WebRequest https://dot.net/v1/dotnet-install.ps1 -OutFile dotnet-install.ps1
-.\dotnet-install.ps1 -Channel 10.0 -Runtime dotnet
-.\dotnet-install.ps1 -Channel 10.0 -Runtime aspnetcore
-# Optional (only for local build/dev):
-.\dotnet-install.ps1 -Channel 10.0
-```
-
-**Bash (Linux/macOS)**
-
-```bash
-curl -fsSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
-chmod +x dotnet-install.sh
-./dotnet-install.sh --channel 10.0 --runtime dotnet
-./dotnet-install.sh --channel 10.0 --runtime aspnetcore
-# Optional (only for local build/dev):
-./dotnet-install.sh --channel 10.0
-```
-
 **1. Add a factory to your executable project**
 
 QueryLens needs a factory class to create an offline `DbContext` for SQL generation. Add it to your **executable startup project** (ASP.NET API, Worker Service, Console app) — not a class library.


### PR DESCRIPTION
Removed installation instructions for .NET 10 SDK from README.

## Summary

-

## Validation

- [ ] `dotnet build EFQueryLens.slnx`
- [ ] `dotnet test EFQueryLens.slnx` (or justified partial test run)
- [ ] `npm run compile` in `src/Plugins/ef-querylens-vscode`

## Checklist

- [ ] Docs updated if behavior/config changed
- [ ] Naming follows `EFQueryLens.*` (projects/namespaces) and `efquerylens.*` (VS Code commands/settings)
- [ ] No unrelated files changed
