### PR TITLE
Fix build command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The connection string is never opened — it only tells EF Core which provider d
 **2. Build the solution**
 
 ```bash
-dotnet build EFQueryLens.slnx
+dotnet build
 ```
 
 **3. Install the extension**


### PR DESCRIPTION
## Summary

-

## Validation

- [ ] `dotnet build EFQueryLens.slnx`
- [ ] `dotnet test EFQueryLens.slnx` (or justified partial test run)
- [ ] `npm run compile` in `src/Plugins/ef-querylens-vscode`

## Checklist

- [ ] Docs updated if behavior/config changed
- [ ] Naming follows `EFQueryLens.*` (projects/namespaces) and `efquerylens.*` (VS Code commands/settings)
- [ ] No unrelated files changed
