### PR TITLE
fix: prefer app host assemblies over test and migration projects

### DIFF
--- a/src/EFQueryLens.Lsp/Hosting/LanguageServerHandler.cs
+++ b/src/EFQueryLens.Lsp/Hosting/LanguageServerHandler.cs
@@ -62,7 +62,7 @@ internal sealed partial class LanguageServerHandler
         var configuration = LspClientConfiguration.FromInitializeRequest(request);
         ApplyClientConfiguration(configuration);
 
-        return CreateInitializeResult(_enableLspHover);
+        return CreateInitializeResult(_enableLspHover, advertiseSetupCommand: IsRiderClient());
     }
 
     [JsonRpcMethod("initialized")]
@@ -122,7 +122,9 @@ internal sealed partial class LanguageServerHandler
         }
     }
 
-    private static JObject CreateInitializeResult(bool enableLspHover)
+    private static JObject CreateInitializeResult(
+        bool enableLspHover,
+        bool advertiseSetupCommand)
     {
         return new JObject
         {
@@ -141,18 +143,29 @@ internal sealed partial class LanguageServerHandler
                 },
                 ["executeCommandProvider"] = new JObject
                 {
-                    ["commands"] = new JArray(
-                        "efquerylens.warmup",
-                        "efquerylens.daemon.restart",
-                        "efquerylens.preview.recalculate",
-                        "efquerylens.preview.structuredHover",
-                        "efquerylens.showsqlpopup",
-                        "efquerylens.opensqleditor",
-                        "efquerylens.copysql",
-                        "efquerylens.reanalyze",
-                        "efquerylens.setup")
+                    ["commands"] = CreateExecuteCommandList(advertiseSetupCommand)
                 },
             },
         };
+    }
+
+    private static JArray CreateExecuteCommandList(bool includeSetupCommand)
+    {
+        var commands = new JArray(
+            "efquerylens.warmup",
+            "efquerylens.daemon.restart",
+            "efquerylens.preview.recalculate",
+            "efquerylens.preview.structuredHover",
+            "efquerylens.showsqlpopup",
+            "efquerylens.opensqleditor",
+            "efquerylens.copysql",
+            "efquerylens.reanalyze");
+
+        if (includeSetupCommand)
+        {
+            commands.Add("efquerylens.setup");
+        }
+
+        return commands;
     }
 }

--- a/src/EFQueryLens.Lsp/Parsing/AssemblyResolver.HostResolution.cs
+++ b/src/EFQueryLens.Lsp/Parsing/AssemblyResolver.HostResolution.cs
@@ -11,7 +11,8 @@ public static partial class AssemblyResolver
         DateTime TimestampUtc,
         bool HasFactory,
         bool HasRuntimeArtifacts,
-        bool LooksLikeRefOrObj);
+        bool LooksLikeRefOrObj,
+        bool IsDiscouragedHost);
 
     /// <summary>
     /// Scans the host project's source files for an <c>IQueryLensDbContextFactory&lt;T&gt;</c>
@@ -283,6 +284,7 @@ public static partial class AssemblyResolver
         foreach (var (csprojPath, exeAssemblyName) in candidates)
         {
             var projDir = Path.GetDirectoryName(csprojPath)!;
+            var isDiscouragedHost = IsDiscouragedHostProject(csprojPath, exeAssemblyName);
 
             // Resolve all output paths for this host executable (bin glob + MSBuild fallback)
             var hostDllPaths = FindProjectOutputDllPaths(csprojPath, exeAssemblyName, ref debugLog);
@@ -318,14 +320,16 @@ public static partial class AssemblyResolver
 
                 debugLog +=
                     $"  -> {exeAssemblyName}: found at {hostDll} (timestamp: {ts:u}, hasFactory: {hasFactory}, " +
-                    $"hasRuntimeArtifacts: {hasRuntimeArtifacts}, looksLikeRefOrObj: {looksLikeRefOrObj})\n";
+                    $"hasRuntimeArtifacts: {hasRuntimeArtifacts}, looksLikeRefOrObj: {looksLikeRefOrObj}, " +
+                    $"isDiscouragedHost: {isDiscouragedHost})\n";
 
                 scored.Add(new CandidateAssembly(
                     hostDll,
                     ts,
                     hasFactory,
                     hasRuntimeArtifacts,
-                    looksLikeRefOrObj));
+                    looksLikeRefOrObj,
+                    isDiscouragedHost));
             }
         }
 
@@ -334,11 +338,13 @@ public static partial class AssemblyResolver
             .Select(g => g
                 .OrderByDescending(x => x.HasFactory ? 1 : 0)
                 .ThenByDescending(x => x.HasRuntimeArtifacts ? 1 : 0)
+                .ThenByDescending(x => x.IsDiscouragedHost ? 0 : 1)
                 .ThenByDescending(x => x.LooksLikeRefOrObj ? 0 : 1)
                 .ThenByDescending(x => x.TimestampUtc)
                 .First())
             .OrderByDescending(x => x.HasFactory ? 1 : 0)
             .ThenByDescending(x => x.HasRuntimeArtifacts ? 1 : 0)
+            .ThenByDescending(x => x.IsDiscouragedHost ? 0 : 1)
             .ThenByDescending(x => x.LooksLikeRefOrObj ? 0 : 1)
             .ThenByDescending(x => x.TimestampUtc)
             .Select(x => x.DllPath)
@@ -491,7 +497,8 @@ public static partial class AssemblyResolver
                 File.GetLastWriteTimeUtc(path),
                 HasFactory: false,
                 HasRuntimeArtifacts: HasExecutableRuntimeArtifacts(path),
-                LooksLikeRefOrObj: LooksLikeRefOrObjPath(path)))
+                LooksLikeRefOrObj: LooksLikeRefOrObjPath(path),
+                IsDiscouragedHost: false))
             .OrderByDescending(x => x.HasRuntimeArtifacts ? 1 : 0)
             .ThenByDescending(x => x.LooksLikeRefOrObj ? 0 : 1)
             .ThenByDescending(x => x.TimestampUtc)
@@ -555,5 +562,25 @@ public static partial class AssemblyResolver
         var normalized = path.Replace('\\', '/');
         return normalized.Contains("/ref/", StringComparison.OrdinalIgnoreCase)
             || normalized.Contains("/obj/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsDiscouragedHostProject(string csprojPath, string assemblyName)
+    {
+        var projectName = Path.GetFileNameWithoutExtension(csprojPath);
+        var normalizedPath = csprojPath.Replace('\\', '/');
+
+        return IsDiscouragedHostName(projectName)
+            || IsDiscouragedHostName(assemblyName)
+            || normalizedPath.Contains("/tests/", StringComparison.OrdinalIgnoreCase)
+            || normalizedPath.Contains("/test/", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsDiscouragedHostName(string value)
+    {
+        return value.EndsWith(".Tests", StringComparison.OrdinalIgnoreCase)
+            || value.EndsWith(".Test", StringComparison.OrdinalIgnoreCase)
+            || value.Contains(".Tests.", StringComparison.OrdinalIgnoreCase)
+            || value.Contains(".Test.", StringComparison.OrdinalIgnoreCase)
+            || value.Contains("Migrations", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/tests/EFQueryLens.Core.Tests/Lsp/AssemblyResolverHostResolutionTests.cs
+++ b/tests/EFQueryLens.Core.Tests/Lsp/AssemblyResolverHostResolutionTests.cs
@@ -101,6 +101,76 @@ public sealed class AssemblyResolverHostResolutionTests
         Assert.Contains($"{Path.DirectorySeparatorChar}net10.0{Path.DirectorySeparatorChar}", resolved!.Replace('/', Path.DirectorySeparatorChar));
     }
 
+    [Fact]
+    public void TryGetTargetAssembly_PrefersAppHostOverNewerMigrationTestHost()
+    {
+        using var workspace = new HostResolutionWorkspace();
+        workspace.WriteSlnx("""
+            <Solution>
+              <Project Path="src/Share.Medics.Applications.Api/Share.Medics.Applications.Api.csproj" />
+              <Project Path="src/Share.Medics.Applications.Core/Share.Medics.Applications.Core.csproj" />
+              <Project Path="tests/Share.Medics.Applications.EFCoreMigrations.Dev.Tests/Share.Medics.Applications.EFCoreMigrations.Dev.Tests.csproj" />
+            </Solution>
+            """);
+        workspace.WriteExecutableCsproj(
+            "src/Share.Medics.Applications.Api/Share.Medics.Applications.Api.csproj",
+            "Share.Medics.Applications.Api");
+        workspace.WriteLibraryCsproj(
+            "src/Share.Medics.Applications.Core/Share.Medics.Applications.Core.csproj",
+            "Share.Medics.Applications.Core");
+        workspace.WriteExecutableCsproj(
+            "tests/Share.Medics.Applications.EFCoreMigrations.Dev.Tests/Share.Medics.Applications.EFCoreMigrations.Dev.Tests.csproj",
+            "Share.Medics.Applications.EFCoreMigrations.Dev.Tests");
+        workspace.WriteDll(
+            "src/Share.Medics.Applications.Core/bin/Debug/net10.0/Share.Medics.Applications.Core.dll",
+            utcTimestamp: DateTime.UtcNow.AddMinutes(-10));
+        workspace.WriteDll(
+            "src/Share.Medics.Applications.Api/bin/Debug/net10.0/Share.Medics.Applications.Api.dll",
+            utcTimestamp: DateTime.UtcNow.AddMinutes(-5));
+        workspace.WriteDll(
+            "src/Share.Medics.Applications.Api/bin/Debug/net10.0/Share.Medics.Applications.Core.dll",
+            utcTimestamp: DateTime.UtcNow.AddMinutes(-5));
+        workspace.WriteDll(
+            "tests/Share.Medics.Applications.EFCoreMigrations.Dev.Tests/bin/Debug/net10.0/Share.Medics.Applications.EFCoreMigrations.Dev.Tests.dll",
+            utcTimestamp: DateTime.UtcNow.AddMinutes(5));
+        workspace.WriteDll(
+            "tests/Share.Medics.Applications.EFCoreMigrations.Dev.Tests/bin/Debug/net10.0/Share.Medics.Applications.Core.dll",
+            utcTimestamp: DateTime.UtcNow.AddMinutes(5));
+        workspace.WriteSourceFile("src/Share.Medics.Applications.Core/Application/Services/ProductService.cs");
+
+        var resolved = AssemblyResolver.TryGetTargetAssembly(workspace.SourceFilePath);
+
+        Assert.NotNull(resolved);
+        Assert.EndsWith("Share.Medics.Applications.Api.dll", resolved!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TryGetTargetAssembly_UsesMigrationTestHostWhenItIsOnlyValidHost()
+    {
+        using var workspace = new HostResolutionWorkspace();
+        workspace.WriteSlnx("""
+            <Solution>
+              <Project Path="src/Share.Medics.Applications.Core/Share.Medics.Applications.Core.csproj" />
+              <Project Path="tests/Share.Medics.Applications.EFCoreMigrations.Dev.Tests/Share.Medics.Applications.EFCoreMigrations.Dev.Tests.csproj" />
+            </Solution>
+            """);
+        workspace.WriteLibraryCsproj(
+            "src/Share.Medics.Applications.Core/Share.Medics.Applications.Core.csproj",
+            "Share.Medics.Applications.Core");
+        workspace.WriteExecutableCsproj(
+            "tests/Share.Medics.Applications.EFCoreMigrations.Dev.Tests/Share.Medics.Applications.EFCoreMigrations.Dev.Tests.csproj",
+            "Share.Medics.Applications.EFCoreMigrations.Dev.Tests");
+        workspace.WriteDll("src/Share.Medics.Applications.Core/bin/Debug/net10.0/Share.Medics.Applications.Core.dll");
+        workspace.WriteDll("tests/Share.Medics.Applications.EFCoreMigrations.Dev.Tests/bin/Debug/net10.0/Share.Medics.Applications.EFCoreMigrations.Dev.Tests.dll");
+        workspace.WriteDll("tests/Share.Medics.Applications.EFCoreMigrations.Dev.Tests/bin/Debug/net10.0/Share.Medics.Applications.Core.dll");
+        workspace.WriteSourceFile("src/Share.Medics.Applications.Core/Application/Services/ProductService.cs");
+
+        var resolved = AssemblyResolver.TryGetTargetAssembly(workspace.SourceFilePath);
+
+        Assert.NotNull(resolved);
+        Assert.EndsWith("Share.Medics.Applications.EFCoreMigrations.Dev.Tests.dll", resolved!, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Theory]
     [InlineData("  -> EXCEPTION: No .slnx or .sln file found.\n", "Could not locate a .slnx or .sln file above this project.")]
     [InlineData("  -> EXCEPTION: No executable project references this library.\n", "No executable host project was found in the solution.")]

--- a/tests/EFQueryLens.Core.Tests/Lsp/HoverRequestCoordinatorTests.cs
+++ b/tests/EFQueryLens.Core.Tests/Lsp/HoverRequestCoordinatorTests.cs
@@ -129,8 +129,13 @@ public sealed class HoverRequestCoordinatorTests
         Assert.True(elapsed.ElapsedMilliseconds < 500);
 
         engine.Complete();
-        var ready = await owner.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.Equal(QueryTranslationStatus.Ready, ready.Status);
+        await WaitUntilReadyAsync(
+            coordinator,
+            project.SourceFilePath,
+            source,
+            position.line,
+            position.character
+        );
     }
 
     [Fact]

--- a/tests/EFQueryLens.Core.Tests/Lsp/LanguageServerHandlerCodeLensTests.cs
+++ b/tests/EFQueryLens.Core.Tests/Lsp/LanguageServerHandlerCodeLensTests.cs
@@ -52,15 +52,27 @@ public sealed class LanguageServerHandlerCodeLensTests
     }
 
     [Fact]
-    public void Initialize_AdvertisesSetupCommand()
+    public void Initialize_ForVsCode_DoesNotAdvertiseSetupCommand()
     {
-        var handler = CreateHandler(new DocumentManager());
+        var commands = WithQueryLensClient("vscode", () =>
+        {
+            var handler = CreateHandler(new DocumentManager());
+            return GetAdvertisedCommands(handler.Initialize());
+        });
 
-        var result = handler.Initialize();
-        var commands = result["capabilities"]?["executeCommandProvider"]?["commands"] as JArray;
+        Assert.DoesNotContain("efquerylens.setup", commands);
+    }
 
-        Assert.NotNull(commands);
-        Assert.Contains(commands!.Values<string>(), command => command == "efquerylens.setup");
+    [Fact]
+    public void Initialize_ForRider_AdvertisesSetupCommand()
+    {
+        var commands = WithQueryLensClient("rider", () =>
+        {
+            var handler = CreateHandler(new DocumentManager());
+            return GetAdvertisedCommands(handler.Initialize());
+        });
+
+        Assert.Contains("efquerylens.setup", commands);
     }
 
     [Fact]
@@ -99,6 +111,28 @@ public sealed class LanguageServerHandlerCodeLensTests
                     Uri = new Uri(uri),
                 },
             });
+    }
+
+    private static string[] GetAdvertisedCommands(JObject initializeResult)
+    {
+        var commands = initializeResult["capabilities"]?["executeCommandProvider"]?["commands"] as JArray;
+
+        Assert.NotNull(commands);
+        return commands!.Values<string>().OfType<string>().ToArray();
+    }
+
+    private static T WithQueryLensClient<T>(string value, Func<T> action)
+    {
+        var previous = Environment.GetEnvironmentVariable("QUERYLENS_CLIENT");
+        Environment.SetEnvironmentVariable("QUERYLENS_CLIENT", value);
+        try
+        {
+            return action();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("QUERYLENS_CLIENT", previous);
+        }
     }
 
     private static LanguageServerHandler CreateHandler(DocumentManager documentManager)


### PR DESCRIPTION
## Summary

- Deprioritize test and migration executable projects during host assembly resolution so QueryLens selects the real app host (e.g. `Share.Medics.Applications.Api.dll`) instead of newer EF Core migration test assemblies when both exist in the same solution.
- Only advertise the `efquerylens.setup` execute command to Rider clients during LSP initialize, avoiding VS Code command registration collisions while keeping setup available where it is needed.
- Add regression tests covering the share-medics-applications-style layout (API + Core + EFCoreMigrations.Dev.Tests) and the fallback when only a migration test host is available.

## Test plan

- [x] `dotnet test EFQueryLens.slnx` — 595 passed, 1 skipped
- [x] `AssemblyResolverHostResolutionTests` — prefers API host over newer migration test host; falls back when migration test is the only host
- [x] `LanguageServerHandlerCodeLensTests` — setup command advertised for Rider only, not VS Code
- [x] Manual: Visual Studio extension with `Share.Medics.Applications.sln` — LINQ hover resolves against `Share.Medics.Applications.Api.dll` and translation succeeds